### PR TITLE
fix: report the rule when a condition evaluates to null

### DIFF
--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -213,14 +213,25 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
             }
         }
 
-        boolean result;
+        Boolean evaluated;
         try {
-            result = MVEL.executeExpression(rule.compiledCondition(), (Object) null, entryMap, Boolean.class);
+            evaluated = MVEL.executeExpression(rule.compiledCondition(), (Object) null, entryMap, Boolean.class);
         } catch (Exception e) {
             String msg = "Failed to evaluate condition for rule '" + rule.rule().getRuleName() + "': " + e.getMessage();
             log.error(msg);
             throw new RuleExecutionException(msg, e);
         }
+
+        // Unboxing a null here would surface as an internal NPE naming MVEL's own
+        // signature, which tells the caller nothing about their rule.
+        if (evaluated == null) {
+            String msg = "Condition for rule '" + rule.rule().getRuleName()
+                    + "' evaluated to null. A condition expression must evaluate to a boolean.";
+            log.error(msg);
+            throw new RuleExecutionException(msg);
+        }
+
+        boolean result = evaluated;
 
         for (RuleListener listener : listeners) {
             try {

--- a/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
@@ -233,6 +233,28 @@ class AbstractRulesEngineTest {
             RuleExecutionException ex = assertThrows(RuleExecutionException.class, () -> engine.run(facts));
             assertTrue(ex.getMessage().contains("bad-action"));
         }
+
+        @Test
+        @DisplayName("condition evaluating to null reports the rule, not an internal NPE")
+        void nullConditionResultReportsRule() {
+            StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+
+            Rule rule = Rule.builder()
+                    .ruleName("null-condition")
+                    .condition("null")
+                    .action("output.put(\"k\", \"v\")")
+                    .priority(1)
+                    .build();
+
+            engine.setRuleList(List.of(rule));
+
+            FactStore<Object> facts = new FactMap<>();
+
+            RuleExecutionException ex = assertThrows(RuleExecutionException.class, () -> engine.run(facts));
+            assertTrue(ex.getMessage().contains("null-condition"));
+            assertTrue(ex.getMessage().contains("must evaluate to a boolean"));
+            assertNull(ex.getCause());
+        }
     }
 
     @Nested


### PR DESCRIPTION
Opened to exercise the new release pipeline end to end — but with a real fix rather than filler, since whatever lands here ships as `1.0.16` on Maven Central permanently.

## The bug

A condition expression that evaluates to `null` was unboxed straight into a `boolean`. The resulting NPE got caught by the generic handler and surfaced verbatim:

```
Failed to evaluate condition for rule 'x': Cannot invoke
"java.lang.Boolean.booleanValue()" because the return value of
"org.mvel2.MVEL.executeExpression(Object, Object, java.util.Map, java.lang.Class)" is null
```

That names MVEL's method signature instead of the caller's mistake. Reproduced against `1.0.15` before fixing.

## The fix

Check for `null` outside the `try` and throw with a message that says what's actually wrong:

```
Condition for rule 'x' evaluated to null. A condition expression must evaluate to a boolean.
```

Same `RuleExecutionException` type, so callers are unaffected — only the message and the absent spurious cause change. Any rule that works today behaves identically.

Covered by a regression test in `AbstractRulesEngineTest`; `./gradlew clean build` passes including the 100% Jacoco gate.

## What this is also testing

Merging this should make release-please open a **`chore(main): release 1.0.16`** PR that bumps `build.gradle`, both README snippets and `CHANGELOG.md`. Worth checking on that PR:

- [ ] version updated in `build.gradle` (single-line marker)
- [ ] **both** README snippets updated (block markers sit outside the code fences — if `build.gradle` changed but README didn't, the markers are wrong)
- [ ] `CHANGELOG.md` gains a `1.0.16` entry with this fix under "Bug Fixes"
- [ ] `.release-please-manifest.json` bumped to `1.0.16`

Nothing publishes until that second PR is merged. Merging it creates tag `v1.0.16`, the GitHub Release, and an **irreversible** push to Maven Central.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xfv1eooXQtWin8yTB883xs
