### PR TITLE
fix: reject non-boolean condition results instead of coercing them

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ The Unruly Engine provides a specific exception hierarchy to help you handle err
 
 - **`UnrulyException`**: The base runtime exception for the engine.
 - **`RuleCompilationException`**: Thrown during `setRuleList()` if a rule has a syntax error in its MVEL condition or action expression.
-- **`RuleExecutionException`**: Thrown during `run()` if a runtime error occurs while evaluating a rule's condition or action (e.g. attempting to invoke a non-existent method).
+- **`RuleExecutionException`**: Thrown during `run()` if a runtime error occurs while evaluating a rule's condition or action (e.g. attempting to invoke a non-existent method), or if a condition evaluates to anything other than a boolean. A condition such as `claim.status` is rejected rather than coerced; write `claim.status == "APPROVED"`.
 
 All exceptions include the name of the offending rule in the message to aid in debugging.
 

--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -213,9 +213,11 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
             }
         }
 
-        Boolean evaluated;
+        // Evaluated without a target type: asking MVEL for Boolean.class coerces any value, so a
+        // condition like `status` (a non-empty string) would silently match instead of failing.
+        Object evaluated;
         try {
-            evaluated = MVEL.executeExpression(rule.compiledCondition(), (Object) null, entryMap, Boolean.class);
+            evaluated = MVEL.executeExpression(rule.compiledCondition(), (Object) null, entryMap);
         } catch (Exception e) {
             String msg = "Failed to evaluate condition for rule '" + rule.rule().getRuleName() + "': " + e.getMessage();
             log.error(msg);
@@ -231,7 +233,12 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
             throw new RuleExecutionException(msg);
         }
 
-        boolean result = evaluated;
+        if (!(evaluated instanceof Boolean result)) {
+            String msg = "Condition for rule '" + rule.rule().getRuleName() + "' evaluated to a "
+                    + evaluated.getClass().getName() + ". A condition expression must evaluate to a boolean.";
+            log.error(msg);
+            throw new RuleExecutionException(msg);
+        }
 
         for (RuleListener listener : listeners) {
             try {

--- a/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
@@ -8,6 +8,8 @@ import io.github.brantunger.unruly.api.exception.RuleExecutionException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 import java.util.Arrays;
 import java.util.HashMap;
@@ -254,6 +256,65 @@ class AbstractRulesEngineTest {
             assertTrue(ex.getMessage().contains("null-condition"));
             assertTrue(ex.getMessage().contains("must evaluate to a boolean"));
             assertNull(ex.getCause());
+        }
+    }
+
+    @Nested
+    @DisplayName("non-boolean condition results")
+    class NonBooleanConditions {
+
+        private Map<String, Object> runCondition(String condition, FactStore<Object> facts) {
+            StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+            engine.setRuleList(List.of(Rule.builder()
+                    .ruleName("non-boolean")
+                    .condition(condition)
+                    .action("output.put(\"fired\", true)")
+                    .priority(1)
+                    .build()));
+            return engine.run(facts);
+        }
+
+        @ParameterizedTest(name = "condition {0} throws instead of being coerced")
+        @ValueSource(strings = {"status", "\"APPROVED\"", "\"false\"", "amount", "0", "5"})
+        void nonBooleanResultThrows(String condition) {
+            FactStore<Object> facts = new FactMap<>();
+            facts.setValue("status", "DENIED");
+            facts.setValue("amount", 5);
+
+            RuleExecutionException ex = assertThrows(RuleExecutionException.class,
+                    () -> runCondition(condition, facts));
+            assertTrue(ex.getMessage().contains("non-boolean"));
+            assertTrue(ex.getMessage().contains("must evaluate to a boolean"));
+            assertNull(ex.getCause());
+        }
+
+        @Test
+        @DisplayName("message names the type the condition produced")
+        void messageNamesResultType() {
+            FactStore<Object> facts = new FactMap<>();
+            facts.setValue("status", "DENIED");
+
+            RuleExecutionException ex = assertThrows(RuleExecutionException.class,
+                    () -> runCondition("status", facts));
+            assertTrue(ex.getMessage().contains("java.lang.String"));
+        }
+
+        @Test
+        @DisplayName("a Boolean-valued fact is still a valid condition")
+        void booleanFactIsValidCondition() {
+            FactStore<Object> facts = new FactMap<>();
+            facts.setValue("approved", Boolean.TRUE);
+
+            assertEquals(true, runCondition("approved", facts).get("fired"));
+        }
+
+        @Test
+        @DisplayName("a false condition still does not match")
+        void falseConditionDoesNotMatch() {
+            FactStore<Object> facts = new FactMap<>();
+            facts.setValue("approved", Boolean.FALSE);
+
+            assertNull(runCondition("approved", facts));
         }
     }
 


### PR DESCRIPTION
Closes #22

## The bug

Conditions were evaluated with `Boolean.class` as the target type, so MVEL coerced whatever the expression produced into a boolean. A condition that isn't a boolean check didn't fail; it matched (or didn't) silently:

| Condition | Fact | Before | After |
|---|---|---|---|
| `status` (forgot `== 'APPROVED'`) | `"DENIED"` | rule **fires** | `RuleExecutionException` |
| `"APPROVED"` | — | rule **fires** | `RuleExecutionException` |
| `amount` | `5` | rule **fires** | `RuleExecutionException` |
| `"false"` / `0` | — | silently no match | `RuleExecutionException` |

## The fix

Evaluate the condition with no target type and require the result to be a `Boolean`. Anything else throws the same `RuleExecutionException` used for the `null` case (#17), naming the rule and the type produced:

```
Condition for rule 'non-boolean' evaluated to a java.lang.String. A condition expression must evaluate to a boolean.
```

The value itself is deliberately left out of the message, since facts may carry sensitive data that would end up in logs.

## ⚠️ Behavior change

Titled `fix:` (patch release), but callers should know: **any rule whose condition returns a non-boolean now throws at `run()` instead of being coerced.** Such rules were already wrong (a typo'd `status` condition matched every non-empty string), so every affected rule was misbehaving before. Rules whose conditions return a boolean, including a bare `Boolean`-valued fact, behave exactly as before. The README exception section now says this.

## Tests

`AbstractRulesEngineTest.NonBooleanConditions`:
- parameterized: `status`, `"APPROVED"`, `"false"`, `amount`, `0`, `5` all throw with no cause
- the message names the result type
- regression guards: a `Boolean` fact still matches when true and doesn't when false

Checked against the unfixed code: 7 of 9 fail (the two regression guards pass, as expected). `./gradlew clean build jacocoTestReport` passes locally, including Checkstyle, PMD and the 100% Jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoPR5C3L6SHbGFQHG9J7k7
