### PR TITLE
fix: make facts read-only in conditions and reserve the output name

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,13 @@ Rule rule = Rule.builder()
     .build();
 ```
 
+**Facts are read-only to rules:**
+- A **condition** cannot assign variables. `claim.approved = true` (a typo for `==`) or a local such as `x = 5; x > 1` throws a `RuleExecutionException` instead of changing the fact for every later rule.
+- An **action** may assign local variables (`score = 10; output.put("score", score)`), but the assignment is visible only within that action. Other rules still see the original facts. Pass results between rules through `output`.
+- `output` is reserved. A fact with that name is rejected with an `IllegalArgumentException` at `run()`.
+
+The engine does not deep-copy fact objects, so a method that mutates one (e.g. `claim.setAmount(0)`) is still seen by later rules.
+
 ### Package Imports
 
 If your MVEL rule expressions reference classes from specific packages (e.g. `Objects.nonNull()`), you can register package imports with the engine. Imports must be configured **before** calling `setRuleList()`, since rules are compiled at that point.

--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -154,10 +154,17 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
      *
      * @param facts The key/value fact store
      * @return A map of variable names to their values
+     * @throws IllegalArgumentException if a fact is named {@code output}, which actions reserve
+     *                                  for the output object
      */
     protected Map<String, Object> unwrapFacts(FactStore<Object> facts) {
         Map<String, Object> entryMap = new HashMap<>();
         for (Map.Entry<String, FactReference<Object>> entry : facts.entrySet()) {
+            // Actions bind the output object to this name, silently hiding a fact of the same name.
+            if (OUTPUT_KEYWORD.equals(entry.getKey())) {
+                throw new IllegalArgumentException("'" + OUTPUT_KEYWORD
+                        + "' is reserved for the output object and cannot be used as a fact name");
+            }
             if (entry.getValue() != null) {
                 entryMap.put(entry.getKey(), entry.getValue().getValue());
             }
@@ -204,10 +211,10 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
     }
 
     private boolean parseCondition(CompiledRule rule, Map<String, Object> entryMap) {
-        Map<String, Object> unmodifiableMap = Collections.unmodifiableMap(entryMap);
+        Map<String, Object> readOnlyFacts = new ReadOnlyFacts(entryMap);
         for (RuleListener listener : listeners) {
             try {
-                listener.beforeEvaluate(rule.rule(), unmodifiableMap);
+                listener.beforeEvaluate(rule.rule(), readOnlyFacts);
             } catch (Exception e) {
                 log.warn("Listener threw exception in beforeEvaluate", e);
             }
@@ -217,7 +224,7 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
         // condition like `status` (a non-empty string) would silently match instead of failing.
         Object evaluated;
         try {
-            evaluated = MVEL.executeExpression(rule.compiledCondition(), (Object) null, entryMap);
+            evaluated = MVEL.executeExpression(rule.compiledCondition(), (Object) null, readOnlyFacts);
         } catch (Exception e) {
             String msg = "Failed to evaluate condition for rule '" + rule.rule().getRuleName() + "': " + e.getMessage();
             log.error(msg);
@@ -242,7 +249,7 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
 
         for (RuleListener listener : listeners) {
             try {
-                listener.afterEvaluate(rule.rule(), unmodifiableMap, result);
+                listener.afterEvaluate(rule.rule(), readOnlyFacts, result);
             } catch (Exception e) {
                 log.warn("Listener threw exception in afterEvaluate", e);
             }

--- a/src/main/java/io/github/brantunger/unruly/core/ReadOnlyFacts.java
+++ b/src/main/java/io/github/brantunger/unruly/core/ReadOnlyFacts.java
@@ -1,0 +1,43 @@
+package io.github.brantunger.unruly.core;
+
+import java.util.AbstractMap;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * A read-only view of the unwrapped facts, handed to condition expressions and listeners.
+ * MVEL writes assignments straight back into the map it evaluates against, so without
+ * this a condition such as {@code approved = true} (a typo for {@code ==}) would change
+ * the fact for every later rule in the run. Rejecting the write names the variable,
+ * which a plain {@link Collections#unmodifiableMap(Map)} would not.
+ */
+final class ReadOnlyFacts extends AbstractMap<String, Object> {
+
+    private final Map<String, Object> facts;
+
+    ReadOnlyFacts(Map<String, Object> facts) {
+        this.facts = facts;
+    }
+
+    @Override
+    public Object get(Object key) {
+        return facts.get(key);
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        return facts.containsKey(key);
+    }
+
+    @Override
+    public Set<Entry<String, Object>> entrySet() {
+        return Collections.unmodifiableMap(facts).entrySet();
+    }
+
+    @Override
+    public Object put(String key, Object value) {
+        throw new UnsupportedOperationException("Cannot assign '" + key
+                + "': facts are read-only in conditions. Use == to compare.");
+    }
+}

--- a/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
@@ -319,6 +319,80 @@ class AbstractRulesEngineTest {
     }
 
     @Nested
+    @DisplayName("fact isolation between rules")
+    class FactIsolation {
+
+        private Rule rule(String name, int priority, String condition, String action) {
+            return Rule.builder()
+                    .ruleName(name)
+                    .condition(condition)
+                    .action(action)
+                    .priority(priority)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("assigning a fact in a condition throws and does not leak to later rules")
+        void conditionAssignmentToFactThrows() {
+            StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+            // `approved = true` is a typo for `==`; it evaluates to a Boolean, so only the
+            // read-only facts catch it.
+            engine.setRuleList(List.of(
+                    rule("typo", 2, "approved = true", "output.put(\"typo\", true)"),
+                    rule("check", 1, "approved == true", "output.put(\"check\", true)")));
+
+            FactStore<Object> facts = new FactMap<>();
+            facts.setValue("approved", Boolean.FALSE);
+
+            RuleExecutionException ex = assertThrows(RuleExecutionException.class, () -> engine.run(facts));
+            assertTrue(ex.getMessage().contains("'typo'"));
+            assertTrue(ex.getMessage().contains("Cannot assign 'approved'"));
+            assertEquals(Boolean.FALSE, facts.getValue("approved"));
+        }
+
+        @Test
+        @DisplayName("creating a new variable in a condition throws")
+        void conditionNewVariableThrows() {
+            StatelessRulesEngine<Map<String, Object>> engine = new StatelessRulesEngine<>(HashMap::new);
+            engine.setRuleList(List.of(rule("new-var", 1, "(flag = true) == true", "output.put(\"k\", 1)")));
+
+            RuleExecutionException ex = assertThrows(RuleExecutionException.class,
+                    () -> engine.run(new FactMap<>()));
+            assertTrue(ex.getMessage().contains("Cannot assign 'flag'"));
+        }
+
+        @Test
+        @DisplayName("assignments in an action are local to that action")
+        void actionAssignmentIsLocal() {
+            StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+            engine.setRuleList(List.of(
+                    rule("assigns", 2, "true", "score = 10; output.put(\"first\", score)"),
+                    rule("reads", 1, "score == 1", "output.put(\"second\", score)")));
+
+            FactStore<Object> facts = new FactMap<>();
+            facts.setValue("score", 1);
+
+            Map<String, Object> result = engine.run(facts);
+            assertEquals(10, result.get("first"));
+            assertEquals(1, result.get("second"));
+            assertEquals(1, facts.getValue("score"));
+        }
+
+        @Test
+        @DisplayName("a fact named 'output' is rejected")
+        void outputFactNameRejected() {
+            StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+            engine.setRuleList(List.of(rule("any", 1, "true", "output.put(\"k\", 1)")));
+
+            FactStore<Object> facts = new FactMap<>();
+            facts.setValue("output", "shadowed");
+
+            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> engine.run(facts));
+            assertTrue(ex.getMessage().contains("'output' is reserved"));
+        }
+    }
+
+    @Nested
     @DisplayName("null fact values")
     class NullFactValues {
 

--- a/src/test/java/io/github/brantunger/unruly/core/ReadOnlyFactsTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/ReadOnlyFactsTest.java
@@ -1,0 +1,43 @@
+package io.github.brantunger.unruly.core;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("ReadOnlyFacts")
+class ReadOnlyFactsTest {
+
+    private final Map<String, Object> backing = new HashMap<>(Map.of("status", "DENIED"));
+    private final Map<String, Object> facts = new ReadOnlyFacts(backing);
+
+    @Test
+    @DisplayName("reads through to the backing map")
+    void readsThrough() {
+        assertEquals("DENIED", facts.get("status"));
+        assertTrue(facts.containsKey("status"));
+        assertFalse(facts.containsKey("missing"));
+        assertEquals(Map.of("status", "DENIED"), facts);
+        assertEquals(1, facts.size());
+    }
+
+    @Test
+    @DisplayName("put names the variable and leaves the backing map unchanged")
+    void putThrows() {
+        UnsupportedOperationException ex = assertThrows(UnsupportedOperationException.class,
+                () -> facts.put("status", "APPROVED"));
+        assertTrue(ex.getMessage().contains("'status'"));
+        assertEquals("DENIED", backing.get("status"));
+    }
+
+    @Test
+    @DisplayName("remove and clear are rejected")
+    void removeAndClearThrow() {
+        assertThrows(UnsupportedOperationException.class, () -> facts.remove("status"));
+        assertThrows(UnsupportedOperationException.class, facts::clear);
+        assertEquals(1, backing.size());
+    }
+}


### PR DESCRIPTION
Closes #23

## The bug

Conditions were evaluated against the live fact map for the run, and MVEL writes assignments straight back into that map. An assignment in one rule's condition therefore changed the fact for every lower-priority rule, while the caller's `FactStore` still held the original value:

```
fact:    approved = false
rule A:  approved = true          ← typo for ==; evaluates to true, so A fires
rule B:  approved == true         ← also fires, because A overwrote the fact
```

The same root cause produced two related silent failures:
- **Actions:** `score = 10` changed only the action's private copy, so it was quietly lost.
- **A fact named `output`:** visible in conditions but hidden by the output object in actions.

## The fix

- **Conditions get a read-only view** (`ReadOnlyFacts`). Any assignment throws `RuleExecutionException` naming the rule and the variable:
  ```
  Failed to evaluate condition for rule 'typo': Cannot assign 'approved': facts are read-only in conditions. Use == to compare.
  ```
  This is a small `AbstractMap` rather than `Collections.unmodifiableMap`, because the JDK exception has a `null` message and would give `"...: null"`.
- **Listeners** receive the same read-only view. Conditions can no longer mutate the map and actions work on a copy, so the view is effectively a stable snapshot for the whole run.
- **Actions keep their current behavior**, which is now documented: assignments are local to the action, and results pass between rules through `output`. I kept this rather than making actions read-only because local temporaries in actions (`x = a * b; output.put(...)`) are legitimate.
- **`output` is reserved:** `unwrapFacts` rejects a fact with that name with `IllegalArgumentException`.

## ⚠️ Behavior changes

Titled `fix:` (patch release), but:
1. **A condition that assigns anything now throws**, and that includes local variables such as `x = 5; x > 1`. MVEL can't tell a typo'd `=` from an intended local, and the typo was the real hazard. Expressions without assignment are unaffected.
2. **A fact named `output` is rejected** at `run()`. Previously it silently read as the output object inside actions.

Not covered: the engine doesn't deep-copy fact objects, so a method that mutates one (`claim.setAmount(0)`) is still visible to later rules. The README now says so.

## Tests

- `AbstractRulesEngineTest.FactIsolation`:
  - an assignment to an existing fact in a condition throws, and the `FactStore` is unchanged
  - a new variable in a condition throws (stateless engine)
  - an assignment in an action stays local: rule A sees `10`, rule B still sees `1`
  - a fact named `output` is rejected
- `ReadOnlyFactsTest` covers the view directly: reads pass through, and `put`, `remove` and `clear` are rejected.

Checked against the code before the engine change: 3 of the 4 `FactIsolation` tests fail. The action-local test passes both before and after, because it pins behavior that already existed and is now documented. `./gradlew clean build jacocoTestReport` passes locally, including the 100% Jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoPR5C3L6SHbGFQHG9J7k7
