### PR TITLE
fix: allow registering listeners during a run without breaking it

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ The rules engine is designed to be configured once and then used concurrently:
 - **`setRuleList()`** should be called once during initialization (e.g. in a constructor or `@PostConstruct` method). This method compiles the MVEL expressions and stores the compiled rules internally. It is **not thread-safe** to call concurrently with `run()`.
 - **`run()`** is safe to call from multiple threads after `setRuleList()` has completed, as it only reads the compiled rules and creates a fresh output object per invocation.
 - **`addImport()` / `addImports()`** must be called before `setRuleList()`. They are not thread-safe.
+- **`registerListener()` / `registerListeners()`** are thread-safe and may be called at any time, even from inside a listener callback. A listener registered during a run may start receiving callbacks partway through that run. A registered listener is called from every thread running the engine, so **listener implementations must be thread-safe**.
 
 ## Exception Handling
 

--- a/src/main/java/io/github/brantunger/unruly/api/RuleListener.java
+++ b/src/main/java/io/github/brantunger/unruly/api/RuleListener.java
@@ -5,8 +5,16 @@ import java.util.Map;
 /**
  * A listener interface to hook into the lifecycle of rule evaluation and execution.
  * Implement this interface to receive callbacks before and after rules are evaluated and executed.
- * Any exceptions thrown by a listener will be caught and logged by the engine, 
+ * Any exceptions thrown by a listener will be caught and logged by the engine,
  * ensuring the core execution is not interrupted.
+ *
+ * <p>
+ * <b>Thread safety:</b> an engine shared across threads invokes the same listener from every
+ * thread calling {@code run()}, possibly at the same time, so implementations must be
+ * thread-safe. Listeners may be registered at any time, including from inside a callback.
+ * A listener registered while a run is in progress may start receiving callbacks partway
+ * through that run.
+ * </p>
  */
 public interface RuleListener {
 

--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Collectors;
 
 import io.github.brantunger.unruly.api.FactReference;
@@ -37,7 +38,9 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
 
     private static final String OUTPUT_KEYWORD = "output";
     private final ParserContext parserContext = new ParserContext(new ParserConfiguration());
-    private final List<RuleListener> listeners = new ArrayList<>();
+    // Copy-on-write: callbacks iterate a snapshot, so registering a listener from another thread
+    // or from inside a callback can't throw ConcurrentModificationException out of run().
+    private final List<RuleListener> listeners = new CopyOnWriteArrayList<>();
     private List<CompiledRule> compiledRules;
 
     /**

--- a/src/test/java/io/github/brantunger/unruly/core/RuleListenerTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/RuleListenerTest.java
@@ -121,4 +121,52 @@ public class RuleListenerTest {
         Map<String, Object> result = engine.run(facts);
         assertEquals(1, result.get("result"));
     }
+
+    @Test
+    @DisplayName("Registering a listener from inside a callback does not break the run")
+    void registeringListenerDuringRunDoesNotThrow() {
+        List<String> events = new ArrayList<>();
+        RuleListener late = new RuleListener() {
+            @Override
+            public void afterExecute(Rule rule, Object output) {
+                events.add("late afterExecute: " + rule.getRuleName());
+            }
+        };
+        // Every callback registers another listener, so each listener loop in the engine
+        // sees the list grow while it is iterating.
+        RuleListener registering = new RuleListener() {
+            @Override
+            public void beforeEvaluate(Rule rule, Map<String, Object> facts) {
+                engine.registerListener(late);
+            }
+
+            @Override
+            public void afterEvaluate(Rule rule, Map<String, Object> facts, boolean matchResult) {
+                engine.registerListener(late);
+            }
+
+            @Override
+            public void beforeExecute(Rule rule, Object output) {
+                engine.registerListeners(List.of(late));
+            }
+
+            @Override
+            public void afterExecute(Rule rule, Object output) {
+                engine.registerListener(late);
+            }
+        };
+        engine.registerListener(registering);
+        engine.setRuleList(List.of(Rule.builder()
+                .ruleName("Rule1")
+                .condition("input == 10")
+                .action("output.put('result', 1)")
+                .build()));
+
+        Map<String, Object> result = engine.run(facts);
+
+        assertEquals(1, result.get("result"));
+        // Listeners registered before afterExecute ran are called for it within the same run.
+        assertFalse(events.isEmpty());
+        assertTrue(events.stream().allMatch("late afterExecute: Rule1"::equals));
+    }
 }


### PR DESCRIPTION
Closes #24

## The bug

`listeners` was a plain `ArrayList`, iterated in four places during `run()`. The per-listener `try/catch` sits *inside* each `for` loop, so a `ConcurrentModificationException` thrown by the iterator escaped `run()` unwrapped. That breaks two documented promises: listener problems never interrupt execution, and engine errors surface as `UnrulyException`.

- **Same thread:** a listener that calls `engine.registerListener(...)` from a callback made every `run()` throw.
- **Across threads:** registering listeners while another thread runs the engine intermittently threw (3 CMEs in 123 runs in the original repro).

## The fix

- `listeners` is now a `CopyOnWriteArrayList`. Each callback loop iterates a snapshot, so registration can never break a run. Registrations are rare and callbacks frequent, which is the case copy-on-write is built for. `registerListeners` stays atomic via `addAll`.
- **Docs:**
  - The `RuleListener` Javadoc and the README Thread Safety section now say that registration is safe at any time.
  - A listener registered mid-run may start receiving callbacks partway through that run.
  - A shared engine calls listeners from many threads at once, so implementations must be thread-safe. This wasn't stated anywhere before.

No behavior change for code that registers listeners up front.

## Tests

`RuleListenerTest.registeringListenerDuringRunDoesNotThrow`: a listener registers another listener from all four callbacks. The run completes normally, and the late listener receives `afterExecute` in the same run.

It uses the deterministic same-thread repro rather than a multi-threaded test, so it can't flake. On the unfixed code it fails with `ConcurrentModificationException`. `./gradlew clean build jacocoTestReport` passes locally, including the 100% Jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoPR5C3L6SHbGFQHG9J7k7
