### PR TITLE
fix: use MVEL's reflective optimizer so concurrent runs with polymorphic facts don't fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,9 +169,23 @@ public class UnrulyController {
 The rules engine is designed to be configured once and then used concurrently:
 
 - **`setRuleList()`** should be called once during initialization (e.g. in a constructor or `@PostConstruct` method). This method compiles the MVEL expressions and stores the compiled rules internally. It is **not thread-safe** to call concurrently with `run()`.
-- **`run()`** is safe to call from multiple threads after `setRuleList()` has completed, as it only reads the compiled rules and creates a fresh output object per invocation.
+- **`run()`** is safe to call from multiple threads after `setRuleList()` has completed. Each invocation creates a fresh output object. The compiled rules are shared, and MVEL updates them internally as they are evaluated, which is why the engine configures MVEL as described below.
 - **`addImport()` / `addImports()`** must be called before `setRuleList()`. They are not thread-safe.
 - **`registerListener()` / `registerListeners()`** are thread-safe and may be called at any time, even from inside a listener callback. A listener registered during a run may start receiving callbacks partway through that run. A registered listener is called from every thread running the engine, so **listener implementations must be thread-safe**.
+
+### MVEL optimizer (JVM-wide)
+
+MVEL's default JIT optimizer generates an accessor for the class it first sees. When the same fact name is later bound to a different class (for example `claim` typed as an interface with several implementations), MVEL falls back to a slower accessor. That fallback is not thread-safe, so concurrent `run()` calls intermittently failed with a `RuleExecutionException` caused by a `ClassCastException`.
+
+To make concurrent use safe by default, **loading the engine switches MVEL's default optimizer to its reflective optimizer for the whole JVM**. MVEL reads this from one global setting, so the choice can't be limited to this engine. It also applies to any other library in the same JVM that uses MVEL.
+
+The reflective optimizer is somewhat slower. A rough single-threaded measurement with three rules went from about 280 ns to 370 ns per `run()`. To keep MVEL's own setting (JIT on, unless you pass `-Dmvel2.disable.jit=true`), start the JVM with:
+
+```
+-Dunruly.mvel.jit=true
+```
+
+With the JIT on, facts whose runtime class varies must not be run concurrently.
 
 ## Exception Handling
 

--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -4,6 +4,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.mvel2.MVEL;
 import org.mvel2.ParserConfiguration;
 import org.mvel2.ParserContext;
+import org.mvel2.optimizers.OptimizerFactory;
 
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -31,10 +32,30 @@ import io.github.brantunger.unruly.api.exception.RuleExecutionException;
  * action expression from a list of {@link Rule} objects when their conditions
  * evaluate to <strong>true</strong>.
  *
+ * <p>
+ * <b>MVEL optimizer:</b> loading this class switches MVEL's default accessor optimizer to
+ * {@link OptimizerFactory#SAFE_REFLECTIVE} for the whole JVM. MVEL's JIT optimizer rewrites
+ * compiled expressions during evaluation and, when the same fact name is bound to different
+ * classes, races between concurrent {@code run()} calls. MVEL selects the optimizer from a
+ * single global setting, so it cannot be scoped to this engine. Set the system property
+ * {@value #JIT_PROPERTY}{@code =true} to leave MVEL's setting untouched; with the JIT on, facts
+ * whose runtime class varies must not be run concurrently.
+ * </p>
+ *
  * @param <O> The output object to instantiate
  */
 @Slf4j
 public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
+
+    /**
+     * System property that, when {@code true}, keeps MVEL's JIT optimizer instead of switching to
+     * the reflective one.
+     */
+    public static final String JIT_PROPERTY = "unruly.mvel.jit";
+
+    static {
+        configureMvel(System.getProperty(JIT_PROPERTY));
+    }
 
     private static final String OUTPUT_KEYWORD = "output";
     private final ParserContext parserContext = new ParserContext(new ParserConfiguration());
@@ -42,6 +63,18 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
     // or from inside a callback can't throw ConcurrentModificationException out of run().
     private final List<RuleListener> listeners = new CopyOnWriteArrayList<>();
     private List<CompiledRule> compiledRules;
+
+    /**
+     * Selects MVEL's reflective optimizer unless the JIT has been opted into. A separate method so both
+     * outcomes can be tested; the static initializer only ever sees one value of the property.
+     *
+     * @param jitProperty The value of {@value #JIT_PROPERTY}, or {@code null} if unset
+     */
+    static void configureMvel(String jitProperty) {
+        if (!Boolean.parseBoolean(jitProperty)) {
+            OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
+        }
+    }
 
     /**
      * Returns an unmodifiable view of the compiled rules list.

--- a/src/test/java/io/github/brantunger/unruly/core/MvelOptimizerTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/MvelOptimizerTest.java
@@ -1,0 +1,124 @@
+package io.github.brantunger.unruly.core;
+
+import io.github.brantunger.unruly.api.FactMap;
+import io.github.brantunger.unruly.api.FactStore;
+import io.github.brantunger.unruly.api.Rule;
+import io.github.brantunger.unruly.api.exception.RuleExecutionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mvel2.optimizers.OptimizerFactory;
+import org.mvel2.optimizers.dynamic.DynamicOptimizer;
+import org.mvel2.optimizers.impl.refl.ReflectiveAccessorOptimizer;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+// Public, as are the fact classes: MVEL's reflective accessors need to reach their getters.
+@DisplayName("MVEL optimizer configuration")
+public class MvelOptimizerTest {
+
+    public static class ClaimA {
+        public int getValue() {
+            return 1;
+        }
+    }
+
+    public static class ClaimB {
+        public int getValue() {
+            return 2;
+        }
+    }
+
+    @Test
+    @DisplayName("the engine selects MVEL's reflective optimizer when loaded")
+    void reflectiveOptimizerIsDefault() {
+        new StatelessRulesEngine<>(HashMap::new);
+
+        assertInstanceOf(ReflectiveAccessorOptimizer.class, OptimizerFactory.getDefaultAccessorCompiler());
+    }
+
+    @Test
+    @DisplayName("opting in to the JIT leaves MVEL's own setting untouched")
+    void jitOptInLeavesMvelUntouched() {
+        try {
+            OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
+
+            AbstractRulesEngine.configureMvel("true");
+            assertInstanceOf(DynamicOptimizer.class, OptimizerFactory.getDefaultAccessorCompiler());
+
+            AbstractRulesEngine.configureMvel("false");
+            assertInstanceOf(ReflectiveAccessorOptimizer.class, OptimizerFactory.getDefaultAccessorCompiler());
+
+            OptimizerFactory.setDefaultOptimizer(OptimizerFactory.DYNAMIC);
+            AbstractRulesEngine.configureMvel(null);
+            assertInstanceOf(ReflectiveAccessorOptimizer.class, OptimizerFactory.getDefaultAccessorCompiler());
+        } finally {
+            OptimizerFactory.setDefaultOptimizer(OptimizerFactory.SAFE_REFLECTIVE);
+        }
+    }
+
+    /**
+     * Regression test for the MVEL deopt race. With the JIT on, warming a rule with one fact class and then
+     * running it concurrently with another made about 2% of calls fail with ClassCastException, so over
+     * 4,800 calls a broken engine fails this test essentially every time.
+     */
+    @Test
+    @DisplayName("polymorphic facts do not fail when run concurrently")
+    void polymorphicFactsUnderConcurrency() throws InterruptedException {
+        int threads = 8;
+        AtomicInteger calls = new AtomicInteger();
+        List<Throwable> failures = new ArrayList<>();
+
+        for (int trial = 0; trial < 200; trial++) {
+            StatelessRulesEngine<Map<String, Object>> engine = new StatelessRulesEngine<>(HashMap::new);
+            engine.setRuleList(List.of(Rule.builder()
+                    .ruleName("poly")
+                    .priority(1)
+                    .condition("claim.value > 0")
+                    .action("output.put('v', claim.value)")
+                    .build()));
+
+            // Enough hits inside DynamicOptimizer's 100 ms window to make the JIT compile an accessor for ClaimA.
+            FactStore<Object> warm = new FactMap<>();
+            warm.setValue("claim", new ClaimA());
+            for (int i = 0; i < 300; i++) {
+                engine.run(warm);
+            }
+
+            CountDownLatch start = new CountDownLatch(1);
+            CountDownLatch done = new CountDownLatch(threads);
+            for (int t = 0; t < threads; t++) {
+                Thread worker = new Thread(() -> {
+                    FactStore<Object> facts = new FactMap<>();
+                    facts.setValue("claim", new ClaimB());
+                    try {
+                        start.await();
+                        for (int i = 0; i < 3; i++) {
+                            calls.incrementAndGet();
+                            engine.run(facts);
+                        }
+                    } catch (RuleExecutionException | InterruptedException e) {
+                        synchronized (failures) {
+                            failures.add(e);
+                        }
+                    } finally {
+                        done.countDown();
+                    }
+                });
+                worker.start();
+            }
+            start.countDown();
+            assertTrue(done.await(30, TimeUnit.SECONDS), "workers did not finish");
+        }
+
+        assertTrue(failures.isEmpty(), () -> failures.size() + " of " + calls + " concurrent runs failed, first: "
+                + failures.get(0));
+    }
+}


### PR DESCRIPTION
Closes #21

## The bug

When the same fact name was bound to different runtime classes (e.g. `claim` typed as an interface with several implementations), concurrent `run()` calls failed intermittently. The failures looked like broken rules:

```
RuleExecutionException: Failed to evaluate condition for rule 'poly': class ClaimB cannot be cast to class ClaimA
```

MVEL's default (dynamic) optimizer JIT-compiles a property accessor for the first class it sees. A different class makes that accessor throw `ClassCastException`, and MVEL's fallback in `ASTNode.deop()` is not thread-safe: it nulls the cached accessor and sets a `DEOP` bit in a plain `int` without a lock. A second thread that fails in that window sees the bit and rethrows. All threads share one compiled expression per rule, so the README's claim that `run()` "only reads the compiled rules" was wrong.

## The fix: JVM-wide, by necessity

⚠️ **Loading the engine now calls `OptimizerFactory.setDefaultOptimizer(SAFE_REFLECTIVE)`, which affects every MVEL user in the JVM.** I tried to keep the change engine-scoped first, but MVEL 2.5.4 doesn't allow it. The property-access path chooses its optimizer from the global default, not the thread-local override:

```java
// org.mvel2.ast.ASTNode#optimize
if ((fields & NOJIT) != 0 || factory != null && factory.isResolveable(getName())) {
  optimizer = getAccessorCompiler(SAFE_REFLECTIVE);
}
else {
  optimizer = getDefaultAccessorCompiler();   // static, JVM-wide
}
```

I confirmed this empirically: setting `OptimizerFactory.setThreadAccessorOptimizer(ReflectiveAccessorOptimizer.class)` on every thread still failed **148 / 9,600** runs of the repro, against a baseline of 199 / 9,600.

Per-thread compiled rules were also rejected. With the JIT still on, each thread would generate its own ASM accessor classes for every rule, which runs into MVEL's class-loader tenure limit (1,500) in a pooled server.

**Opt-out:** `-Dunruly.mvel.jit=true` leaves MVEL's setting untouched (JIT on unless `-Dmvel2.disable.jit=true`). The decision lives in a small package-private `configureMvel(String)` so both branches are unit-tested. The static initializer only ever sees one value of the property.

## Cost

This is a crude single-threaded micro-measurement, not JMH: 3 rules, stateful engine, 200k runs per round, best of 5, two runs each.

| Optimizer | ns / `run()` |
|---|---|
| dynamic (JIT) | 279–280 |
| reflective | 367–371 |

That's about 30% per run. The reflective accessors handle polymorphism without deoptimizing, so the race disappears.

## Docs

- **README, Thread Safety:** corrected the "only reads" wording and added an *MVEL optimizer (JVM-wide)* section. It covers the race, the global side effect, the cost, the opt-out, and the fact that with the JIT on, varying fact classes must not be run concurrently.
- **`AbstractRulesEngine` Javadoc:** says the same, and exposes the `JIT_PROPERTY` constant.

## Tests

`MvelOptimizerTest`:
- **`polymorphicFactsUnderConcurrency`**: the repro ported into the suite. Each of 200 trials warms a rule with `ClaimA`, past the JIT's tenuring threshold, then runs it from 8 threads with `ClaimB`. It asserts zero failures and takes about 0.4 s. With the static initializer disabled it fails: **211 of 4,378 concurrent runs failed**.
- **`reflectiveOptimizerIsDefault`**: loading an engine selects `ReflectiveAccessorOptimizer`.
- **`jitOptInLeavesMvelUntouched`**: `"true"` leaves a `DYNAMIC` default alone, while `"false"` and `null` switch to reflective. It restores the setting afterwards.

`./gradlew clean build jacocoTestReport` passes locally, including the 100% Jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoPR5C3L6SHbGFQHG9J7k7
