### PR TITLE
fix: catch more malformed expressions at setRuleList and document MVEL's lenient parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ With the JIT on, facts whose runtime class varies must not be run concurrently.
 The Unruly Engine provides a specific exception hierarchy to help you handle errors gracefully:
 
 - **`UnrulyException`**: The base runtime exception for the engine.
-- **`RuleCompilationException`**: Thrown during `setRuleList()` if a rule has a syntax error in its MVEL condition or action expression.
+- **`RuleCompilationException`**: Thrown during `setRuleList()` if a rule has a syntax error in its MVEL condition or action expression. MVEL's parser is lenient, so not every mistake is caught at this point. For example, `true)` and `output.put("k" 1)` compile without error and only fail with a `RuleExecutionException` when that rule is evaluated. Test each rule against sample facts rather than relying on `setRuleList()` alone.
 - **`RuleExecutionException`**: Thrown during `run()` if a runtime error occurs while evaluating a rule's condition or action (e.g. attempting to invoke a non-existent method), or if a condition evaluates to anything other than a boolean. A condition such as `claim.status` is rejected rather than coerced; write `claim.status == "APPROVED"`.
 
 All exceptions include the name of the offending rule in the message to aid in debugging.

--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -336,13 +336,21 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
                     "Rule '" + ruleName + "' has a null or blank action expression");
         }
         try {
-            Serializable compiledCondition = MVEL.compileExpression(rule.getCondition(), parserContext);
-            Serializable compiledAction = MVEL.compileExpression(rule.getAction(), parserContext);
+            Serializable compiledCondition = compileExpression(rule.getCondition());
+            Serializable compiledAction = compileExpression(rule.getAction());
             return new CompiledRule(rule, compiledCondition, compiledAction);
         } catch (Exception e) {
             String msg = "Can not compile rule '" + ruleName + "'. Error: " + e.getMessage();
             log.error(msg);
             throw new RuleCompilationException(msg, e);
         }
+    }
+
+    private Serializable compileExpression(String expression) {
+        // compileExpression alone accepts some malformed input (e.g. `x == == 1`) and defers the error to
+        // run(). The analysis pass catches more of it up front. It gets its own ParserContext because
+        // analysis records variables on the context, but it shares the configuration so imports resolve.
+        MVEL.analysisCompile(expression, new ParserContext(parserContext.getParserConfiguration()));
+        return MVEL.compileExpression(expression, parserContext);
     }
 }

--- a/src/test/java/io/github/brantunger/unruly/core/SyntaxValidationTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/SyntaxValidationTest.java
@@ -1,0 +1,101 @@
+package io.github.brantunger.unruly.core;
+
+import io.github.brantunger.unruly.api.FactMap;
+import io.github.brantunger.unruly.api.FactStore;
+import io.github.brantunger.unruly.api.Rule;
+import io.github.brantunger.unruly.api.exception.RuleCompilationException;
+import io.github.brantunger.unruly.api.exception.RuleExecutionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("syntax validation at setRuleList()")
+class SyntaxValidationTest {
+
+    private static Rule rule(String condition, String action) {
+        return Rule.builder()
+                .ruleName("syntax")
+                .condition(condition)
+                .action(action)
+                .priority(1)
+                .build();
+    }
+
+    @Test
+    @DisplayName("a doubled operator in a condition is rejected at compile time")
+    void doubledOperatorInConditionRejected() {
+        StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+
+        RuleCompilationException ex = assertThrows(RuleCompilationException.class,
+                () -> engine.setRuleList(List.of(rule("x == == 1", "output.put('k', 1)"))));
+        assertTrue(ex.getMessage().contains("'syntax'"));
+    }
+
+    @Test
+    @DisplayName("a doubled operator in an action is rejected at compile time")
+    void doubledOperatorInActionRejected() {
+        StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+
+        assertThrows(RuleCompilationException.class,
+                () -> engine.setRuleList(List.of(rule("true", "x == == 1"))));
+    }
+
+    @ParameterizedTest(name = "valid expression {0} still compiles")
+    @ValueSource(strings = {
+            "Objects.nonNull(name) && name.startsWith('J')",
+            "status in ['A', 'B']",
+            "name ~= '[a-z]+'",
+            "claim.?address == null",
+            "var y = x + 1; y > 1",
+            "($ in list if $ > 1).size() > 0",
+    })
+    void validConditionsStillCompile(String condition) {
+        StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+        engine.addImport("java.util");
+
+        assertDoesNotThrow(() -> engine.setRuleList(List.of(rule(condition, "output.put('k', 1)"))));
+    }
+
+    @ParameterizedTest(name = "valid action {0} still compiles")
+    @ValueSource(strings = {
+            "if (x > 1) { output.put('a', 1); } else { output.put('b', 2); }",
+            "foreach (i : list) { output.put(i, i); }",
+            "def f(a) { a * 2 }; output.put('d', f(x))",
+            "with (output) { put('a', 1), put('b', 2) }",
+            "score = 10; output.put('s', score)",
+    })
+    void validActionsStillCompile(String action) {
+        StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+
+        assertDoesNotThrow(() -> engine.setRuleList(List.of(rule("true", action))));
+    }
+
+    @Test
+    @DisplayName("imports added before setRuleList() are visible to the analysis pass")
+    void importsVisibleToAnalysis() {
+        StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+        engine.addImport("java.util");
+        engine.setRuleList(List.of(rule("Objects.nonNull(name)", "output.put('k', 1)")));
+
+        FactStore<Object> facts = new FactMap<>();
+        facts.setValue("name", "n");
+        assertEquals(1, engine.run(facts).get("k"));
+    }
+
+    /** MVEL's parser still accepts this; pinned so a future MVEL upgrade that catches it is noticed. */
+    @Test
+    @DisplayName("known limitation: a stray closing parenthesis is only reported at run()")
+    void strayParenthesisOnlyFailsAtRun() {
+        StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+        engine.setRuleList(List.of(rule("true)", "output.put('k', 1)")));
+
+        assertThrows(RuleExecutionException.class, () -> engine.run(new FactMap<>()));
+    }
+}


### PR DESCRIPTION
Closes #25

## The bug

The README promised that syntax errors surface as `RuleCompilationException` from `setRuleList()`. However, `MVEL.compileExpression` accepts some malformed expressions and only fails when the rule is actually evaluated, as a `RuleExecutionException`. A broken rule could therefore pass startup and fail in production, possibly only for the rare input that reaches it.

## What MVEL 2.5.4 can and can't catch

Before changing anything, I ran the three malformed expressions from the issue, plus a few more, through each compile mode MVEL offers:

| Expression | `compileExpression` | `ExpressionCompiler` error list | strict typing | `analysisCompile` |
|---|---|---|---|---|
| `x == == 1` | accepted | accepted | accepted | **rejected** |
| `true)` | accepted | accepted | rejected* | accepted |
| `output.put("k" 1)` | accepted | accepted | rejected* | accepted |
| `output.put('a',)` | accepted | accepted | — | accepted |

\* **Strict typing is not an option.** It needs the type of every input declared up front. With the untyped fact map it also rejects valid rules: `claim.amount > 100`, `output.put("k", 1)`, `Objects.nonNull(name)`.

`analysisCompile` is the only mode that adds anything without breaking valid rules. I ran it over 42 valid expressions and it accepted all of them. They included:
- the README's large example condition
- `in`, `contains`, `~=`, `is`, `instanceof`, null-safe `.?`, projections and filters
- `if` / `foreach` / `for` / `def` / `with` blocks
- inline lists and maps, local `var`, comments, and `and` / `or`

## The fix

- **Compile check:** each condition and action now goes through `MVEL.analysisCompile` before `compileExpression`. The analysis pass gets its own `ParserContext`, because it records variables on the context, but shares the engine's `ParserConfiguration` so imports still resolve. Failures surface as the existing `RuleCompilationException` naming the rule.
- **README:** no longer promises that every syntax error is caught at `setRuleList()`. It gives `true)` and `output.put("k" 1)` as examples that only fail at `run()`, and recommends testing each rule against sample facts.

This is a partial fix by necessity. Doubled and misplaced operators are now caught at startup, and the remaining gap is documented rather than hidden.

## ⚠️ Behavior change

A rule that MVEL's analysis pass rejects now fails at `setRuleList()` instead of at `run()`. Every such rule I found was already broken. The risk is a valid construct that analysis rejects but compilation accepts. None turned up in the 42-expression sweep, and the parameterized tests pin a representative set of them.

## Tests

`SyntaxValidationTest`:
- **Doubled operators:** `x == == 1` as a condition and as an action is rejected at `setRuleList()`. With the analysis pass removed, **both tests fail**. I rewrote the action case after finding my first version (`output.put('k', 1 == == 1)`) was already rejected by `compileExpression`.
- **Valid expressions still compile:** 6 conditions and 5 actions, including block statements, projections and local variables.
- **Imports:** imports added before `setRuleList()` are visible to the analysis pass.
- **Known limitation:** `true)` still only fails at `run()`. This is pinned so a future MVEL upgrade that catches it gets noticed.

`./gradlew clean build jacocoTestReport` passes locally, including the 100% Jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoPR5C3L6SHbGFQHG9J7k7
