### PR TITLE
feat: add RuleListener.onError so a failed rule always closes its before callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,3 +213,24 @@ engine.registerListener(new RuleListener() {
 // Or use the out-of-the-box LoggingRuleListener (logs all events at DEBUG level via SLF4J)
 engine.registerListener(new LoggingRuleListener());
 ```
+
+Every `beforeEvaluate` / `beforeExecute` callback is followed by exactly one closing call. That's the matching `afterEvaluate` / `afterExecute` when the rule succeeds, or `onError` when its condition or action fails. `onError` receives the `RuleExecutionException` that `run()` then throws. Anything you open in a `before*` callback, such as a timer or tracing span, can therefore always be closed:
+
+```java
+engine.registerListener(new RuleListener() {
+    @Override
+    public void beforeExecute(Rule rule, Object output) {
+        startSpan(rule);
+    }
+
+    @Override
+    public void afterExecute(Rule rule, Object output) {
+        endSpan(rule);
+    }
+
+    @Override
+    public void onError(Rule rule, RuleExecutionException error) {
+        endSpan(rule, error);
+    }
+});
+```

--- a/src/main/java/io/github/brantunger/unruly/api/LoggingRuleListener.java
+++ b/src/main/java/io/github/brantunger/unruly/api/LoggingRuleListener.java
@@ -1,5 +1,6 @@
 package io.github.brantunger.unruly.api;
 
+import io.github.brantunger.unruly.api.exception.RuleExecutionException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,5 +32,10 @@ public class LoggingRuleListener implements RuleListener {
     @Override
     public void afterExecute(Rule rule, Object output) {
         log.debug("Executed action for rule: {}", rule.getRuleName());
+    }
+
+    @Override
+    public void onError(Rule rule, RuleExecutionException error) {
+        log.debug("Failed rule: {} | Error: {}", rule.getRuleName(), error.getMessage());
     }
 }

--- a/src/main/java/io/github/brantunger/unruly/api/RuleListener.java
+++ b/src/main/java/io/github/brantunger/unruly/api/RuleListener.java
@@ -1,5 +1,7 @@
 package io.github.brantunger.unruly.api;
 
+import io.github.brantunger.unruly.api.exception.RuleExecutionException;
+
 import java.util.Map;
 
 /**
@@ -56,6 +58,24 @@ public interface RuleListener {
      * @param output The output object after execution.
      */
     default void afterExecute(Rule rule, Object output) {
+        // default empty implementation
+    }
+
+    /**
+     * Called when evaluating a rule's condition or executing its action fails, in place of
+     * {@link #afterEvaluate} or {@link #afterExecute}. Every {@code before*} callback is followed by
+     * exactly one call to the matching {@code after*} method or to this method, so resources opened
+     * in {@code before*} (timers, tracing spans, logging context) can always be closed.
+     *
+     * <p>
+     * {@code error} is the exception that {@code run()} throws once all listeners have been notified.
+     * Errors found while compiling rules in {@code setRuleList()} are not reported here.
+     * </p>
+     *
+     * @param rule  The rule whose condition or action failed.
+     * @param error The exception about to be thrown from {@code run()}.
+     */
+    default void onError(Rule rule, RuleExecutionException error) {
         // default empty implementation
     }
 }

--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -262,25 +262,20 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
         try {
             evaluated = MVEL.executeExpression(rule.compiledCondition(), (Object) null, readOnlyFacts);
         } catch (Exception e) {
-            String msg = "Failed to evaluate condition for rule '" + rule.rule().getRuleName() + "': " + e.getMessage();
-            log.error(msg);
-            throw new RuleExecutionException(msg, e);
+            throw failure(rule, "Failed to evaluate condition for rule '" + rule.rule().getRuleName() + "': "
+                    + e.getMessage(), e);
         }
 
         // Unboxing a null here would surface as an internal NPE naming MVEL's own
         // signature, which tells the caller nothing about their rule.
         if (evaluated == null) {
-            String msg = "Condition for rule '" + rule.rule().getRuleName()
-                    + "' evaluated to null. A condition expression must evaluate to a boolean.";
-            log.error(msg);
-            throw new RuleExecutionException(msg);
+            throw failure(rule, "Condition for rule '" + rule.rule().getRuleName()
+                    + "' evaluated to null. A condition expression must evaluate to a boolean.", null);
         }
 
         if (!(evaluated instanceof Boolean result)) {
-            String msg = "Condition for rule '" + rule.rule().getRuleName() + "' evaluated to a "
-                    + evaluated.getClass().getName() + ". A condition expression must evaluate to a boolean.";
-            log.error(msg);
-            throw new RuleExecutionException(msg);
+            throw failure(rule, "Condition for rule '" + rule.rule().getRuleName() + "' evaluated to a "
+                    + evaluated.getClass().getName() + ". A condition expression must evaluate to a boolean.", null);
         }
 
         for (RuleListener listener : listeners) {
@@ -309,9 +304,8 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
         try {
             MVEL.executeExpression(rule.compiledAction(), (Object) null, input);
         } catch (Exception e) {
-            String msg = "Failed to execute action for rule '" + rule.rule().getRuleName() + "': " + e.getMessage();
-            log.error(msg);
-            throw new RuleExecutionException(msg, e);
+            throw failure(rule, "Failed to execute action for rule '" + rule.rule().getRuleName() + "': "
+                    + e.getMessage(), e);
         }
 
         for (RuleListener listener : listeners) {
@@ -323,6 +317,25 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
         }
 
         return outputResult;
+    }
+
+    /**
+     * Logs a run-time failure and tells every listener through {@link RuleListener#onError}, so each
+     * {@code before*} callback still gets a closing call. Returns the exception for the caller to throw.
+     */
+    private RuleExecutionException failure(CompiledRule rule, String msg, Exception cause) {
+        log.error(msg);
+        RuleExecutionException error = cause == null
+                ? new RuleExecutionException(msg)
+                : new RuleExecutionException(msg, cause);
+        for (RuleListener listener : listeners) {
+            try {
+                listener.onError(rule.rule(), error);
+            } catch (Exception e) {
+                log.warn("Listener threw exception in onError", e);
+            }
+        }
+        return error;
     }
 
     private CompiledRule compileRule(Rule rule) {

--- a/src/test/java/io/github/brantunger/unruly/core/RuleListenerErrorTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/RuleListenerErrorTest.java
@@ -1,0 +1,133 @@
+package io.github.brantunger.unruly.core;
+
+import io.github.brantunger.unruly.api.FactMap;
+import io.github.brantunger.unruly.api.FactStore;
+import io.github.brantunger.unruly.api.LoggingRuleListener;
+import io.github.brantunger.unruly.api.Rule;
+import io.github.brantunger.unruly.api.RuleListener;
+import io.github.brantunger.unruly.api.exception.RuleExecutionException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("RuleListener.onError")
+class RuleListenerErrorTest {
+
+    private final List<String> events = new CopyOnWriteArrayList<>();
+    private final List<RuleExecutionException> errors = new CopyOnWriteArrayList<>();
+
+    private final RuleListener recorder = new RuleListener() {
+        @Override
+        public void beforeEvaluate(Rule rule, Map<String, Object> facts) {
+            events.add("beforeEvaluate");
+        }
+
+        @Override
+        public void afterEvaluate(Rule rule, Map<String, Object> facts, boolean matchResult) {
+            events.add("afterEvaluate");
+        }
+
+        @Override
+        public void beforeExecute(Rule rule, Object output) {
+            events.add("beforeExecute");
+        }
+
+        @Override
+        public void afterExecute(Rule rule, Object output) {
+            events.add("afterExecute");
+        }
+
+        @Override
+        public void onError(Rule rule, RuleExecutionException error) {
+            events.add("onError:" + rule.getRuleName());
+            errors.add(error);
+        }
+    };
+
+    private RuleExecutionException runExpectingFailure(String condition, String action) {
+        StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+        engine.registerListener(recorder);
+        engine.setRuleList(List.of(Rule.builder()
+                .ruleName("failing")
+                .condition(condition)
+                .action(action)
+                .priority(1)
+                .build()));
+        FactStore<Object> facts = new FactMap<>();
+        facts.setValue("status", "OPEN");
+
+        return assertThrows(RuleExecutionException.class, () -> engine.run(facts));
+    }
+
+    @Test
+    @DisplayName("a condition that throws ends beforeEvaluate with onError")
+    void conditionException() {
+        RuleExecutionException thrown = runExpectingFailure("missing > 1", "output.put('k', 1)");
+
+        assertEquals(List.of("beforeEvaluate", "onError:failing"), events);
+        assertSame(thrown, errors.get(0));
+        assertNotNull(thrown.getCause());
+    }
+
+    @Test
+    @DisplayName("a condition that evaluates to null ends beforeEvaluate with onError")
+    void conditionNull() {
+        RuleExecutionException thrown = runExpectingFailure("null", "output.put('k', 1)");
+
+        assertEquals(List.of("beforeEvaluate", "onError:failing"), events);
+        assertSame(thrown, errors.get(0));
+    }
+
+    @Test
+    @DisplayName("a non-boolean condition ends beforeEvaluate with onError")
+    void conditionNonBoolean() {
+        RuleExecutionException thrown = runExpectingFailure("status", "output.put('k', 1)");
+
+        assertEquals(List.of("beforeEvaluate", "onError:failing"), events);
+        assertSame(thrown, errors.get(0));
+    }
+
+    @Test
+    @DisplayName("an action that throws ends beforeExecute with onError")
+    void actionException() {
+        RuleExecutionException thrown = runExpectingFailure("true", "output.noSuchMethod()");
+
+        assertEquals(List.of("beforeEvaluate", "afterEvaluate", "beforeExecute", "onError:failing"), events);
+        assertSame(thrown, errors.get(0));
+    }
+
+    @Test
+    @DisplayName("a listener that throws in onError does not replace the rule's exception")
+    void throwingOnErrorIsContained() {
+        StatelessRulesEngine<Map<String, Object>> engine = new StatelessRulesEngine<>(HashMap::new);
+        engine.registerListener(new RuleListener() {
+            @Override
+            public void onError(Rule rule, RuleExecutionException error) {
+                throw new IllegalStateException("listener bug");
+            }
+        });
+        engine.registerListener(recorder);
+        engine.setRuleList(List.of(Rule.builder().ruleName("failing").condition("null")
+                .action("output.put('k', 1)").build()));
+
+        RuleExecutionException thrown = assertThrows(RuleExecutionException.class, () -> engine.run(new FactMap<>()));
+        assertTrue(thrown.getMessage().contains("evaluated to null"));
+        assertEquals(List.of(thrown), errors, "later listeners are still notified");
+    }
+
+    @Test
+    @DisplayName("default and logging implementations accept onError")
+    void defaultAndLoggingImplementations() {
+        Rule rule = Rule.builder().ruleName("r").condition("true").action("x").build();
+        RuleExecutionException error = new RuleExecutionException("boom");
+
+        assertDoesNotThrow(() -> new RuleListener() { }.onError(rule, error));
+        assertDoesNotThrow(() -> new LoggingRuleListener().onError(rule, error));
+    }
+}


### PR DESCRIPTION
Closes #26

## The problem

`beforeEvaluate` and `beforeExecute` always fire. If the condition or action then failed, the matching `afterEvaluate` / `afterExecute` was skipped and no other callback fired. Failures include MVEL throwing, a condition evaluating to `null`, or a non-boolean result. Any listener that opens something in `before*` and closes it in `after*` leaked it on every failed rule, for example a timer, a tracing span, or MDC/logging context. With `LoggingRuleListener`, an "Evaluating..." line was never followed by a result.

## The change

`RuleListener` gets a new default method:

```java
default void onError(Rule rule, RuleExecutionException error)
```

- **Contract (Javadoc):** every `before*` is followed by exactly one call, either to the matching `after*` or to `onError`.
- **Error argument:** `error` is the same instance that `run()` then throws, so a listener can record the message and cause.
- **Where it's called:** the engine calls it at all four run-time failure points: condition threw, condition was `null`, condition was non-boolean, and action threw. A new private `failure(...)` helper logs, notifies listeners and returns the exception. That replaces four copies of the log-and-throw code.
- **Listener exceptions:** an exception thrown from `onError` is caught and logged like the other callbacks, so it can't replace the rule's exception or stop later listeners from being notified.
- **Compile errors:** errors from `setRuleList()` are not reported through `onError`, because no `before*` callback has run.
- **`LoggingRuleListener`:** logs failures at DEBUG, next to its other lifecycle lines.
- **README:** the listener section now states the before/after-or-onError contract, with an example that closes a span.

## Why `onError` rather than calling `after*` from `finally`

`afterEvaluate` takes a `boolean matchResult`, and a failed condition has no result to give it. Any value would be a lie, and listeners couldn't tell a failure from a real `false`.

## Compatibility

Titled `feat:` because this adds public API, so release-please will cut a **minor** release. It's a default method, so existing `RuleListener` implementations compile and behave as before. Only listeners that override `onError` see anything new.

## Tests

`RuleListenerErrorTest` records the exact callback sequence for each failure point and checks that `onError` receives the same exception `run()` throws:

| Failure | Sequence |
|---|---|
| condition throws | `beforeEvaluate`, `onError` |
| condition is `null` | `beforeEvaluate`, `onError` |
| condition is non-boolean | `beforeEvaluate`, `onError` |
| action throws | `beforeEvaluate`, `afterEvaluate`, `beforeExecute`, `onError` |

It also checks that a listener throwing in `onError` doesn't replace the rule's exception and that later listeners are still notified. Coverage tests exercise the default and logging implementations.

With the listener notification in `failure(...)` removed, **5 of the 6 tests fail**. The sixth only exercises the default and logging implementations directly. `./gradlew clean build jacocoTestReport` passes locally, including the 100% Jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoPR5C3L6SHbGFQHG9J7k7
