### PR TITLE
fix: report invalid rules as RuleCompilationException

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ With the JIT on, facts whose runtime class varies must not be run concurrently.
 The Unruly Engine provides a specific exception hierarchy to help you handle errors gracefully:
 
 - **`UnrulyException`**: The base runtime exception for the engine.
-- **`RuleCompilationException`**: Thrown during `setRuleList()` if a rule has a syntax error in its MVEL condition or action expression. MVEL's parser is lenient, so not every mistake is caught at this point. For example, `true)` and `output.put("k" 1)` compile without error and only fail with a `RuleExecutionException` when that rule is evaluated. Test each rule against sample facts rather than relying on `setRuleList()` alone.
+- **`RuleCompilationException`**: Thrown during `setRuleList()` if a rule has a syntax error in its MVEL condition or action expression, has a null or blank condition or action, or if the rule list contains a `null` rule. MVEL's parser is lenient, so not every mistake is caught at this point. For example, `true)` and `output.put("k" 1)` compile without error and only fail with a `RuleExecutionException` when that rule is evaluated. Test each rule against sample facts rather than relying on `setRuleList()` alone.
 - **`RuleExecutionException`**: Thrown during `run()` if a runtime error occurs while evaluating a rule's condition or action (e.g. attempting to invoke a non-existent method), or if a condition evaluates to anything other than a boolean. A condition such as `claim.status` is rejected rather than coerced; write `claim.status == "APPROVED"`.
 
 All exceptions include the name of the offending rule in the message to aid in debugging.

--- a/src/main/java/io/github/brantunger/unruly/api/RulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/api/RulesEngine.java
@@ -16,7 +16,9 @@ public interface RulesEngine<O> {
     /**
      * Set the rule list for use in processing rules through the rules engine
      * @param ruleList The list of {@link Rule} objects
-     * @throws io.github.brantunger.unruly.api.exception.RuleCompilationException if a rule fails to compile
+     * @throws io.github.brantunger.unruly.api.exception.RuleCompilationException if a rule fails to compile, has a
+     *         null or blank condition or action, or if the list contains a {@code null} rule
+     * @throws NullPointerException if {@code ruleList} itself is {@code null}
      */
     void setRuleList(List<Rule> ruleList);
 

--- a/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
+++ b/src/main/java/io/github/brantunger/unruly/core/AbstractRulesEngine.java
@@ -132,6 +132,12 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
     @Override
     public void setRuleList(List<Rule> ruleList) {
         Objects.requireNonNull(ruleList, "ruleList must not be null");
+        // Checked before sorting, which would otherwise fail with a bare NPE from Rule::getPriority.
+        for (int i = 0; i < ruleList.size(); i++) {
+            if (ruleList.get(i) == null) {
+                throw new RuleCompilationException("Rule at index " + i + " of the rule list is null");
+            }
+        }
         this.compiledRules = ruleList.stream()
                 .sorted(Comparator.comparing(
                         Rule::getPriority,
@@ -341,11 +347,11 @@ public abstract class AbstractRulesEngine<O> implements RulesEngine<O> {
     private CompiledRule compileRule(Rule rule) {
         String ruleName = rule.getRuleName() != null ? rule.getRuleName() : "(unnamed)";
         if (rule.getCondition() == null || rule.getCondition().isBlank()) {
-            throw new IllegalArgumentException(
+            throw new RuleCompilationException(
                     "Rule '" + ruleName + "' has a null or blank condition expression");
         }
         if (rule.getAction() == null || rule.getAction().isBlank()) {
-            throw new IllegalArgumentException(
+            throw new RuleCompilationException(
                     "Rule '" + ruleName + "' has a null or blank action expression");
         }
         try {

--- a/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
+++ b/src/test/java/io/github/brantunger/unruly/core/AbstractRulesEngineTest.java
@@ -430,6 +430,27 @@ class AbstractRulesEngineTest {
             NullPointerException ex = assertThrows(NullPointerException.class, () -> engine.setRuleList(null));
             assertTrue(ex.getMessage().contains("ruleList must not be null"));
         }
+
+        @Test
+        @DisplayName("a null rule in the list throws RuleCompilationException naming its index")
+        void nullRuleElementThrows() {
+            StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+            Rule good = Rule.builder().ruleName("good").condition("true").action("output.put('k', 1)").build();
+
+            RuleCompilationException ex = assertThrows(RuleCompilationException.class,
+                    () -> engine.setRuleList(Arrays.asList(good, null)));
+            assertTrue(ex.getMessage().contains("index 1"));
+        }
+
+        @Test
+        @DisplayName("validation errors can be caught as UnrulyException")
+        void validationErrorsAreUnrulyExceptions() {
+            StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
+            Rule blank = Rule.builder().ruleName("blank").condition(" ").action("output.put('k', 1)").build();
+
+            assertThrows(io.github.brantunger.unruly.api.exception.UnrulyException.class,
+                    () -> engine.setRuleList(List.of(blank)));
+        }
     }
 
     @Nested
@@ -437,39 +458,39 @@ class AbstractRulesEngineTest {
     class RuleConditionValidation {
 
         @Test
-        @DisplayName("null condition throws IllegalArgumentException naming the rule")
+        @DisplayName("null condition throws RuleCompilationException naming the rule")
         void nullConditionThrows() {
             StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
             Rule rule = Rule.builder().ruleName("my-rule").condition(null)
                     .action("output.put(\"k\",1)").build();
 
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            RuleCompilationException ex = assertThrows(RuleCompilationException.class,
                     () -> engine.setRuleList(List.of(rule)));
             assertTrue(ex.getMessage().contains("my-rule"), "error should name the offending rule");
             assertTrue(ex.getMessage().contains("condition"));
         }
 
         @Test
-        @DisplayName("blank condition throws IllegalArgumentException naming the rule")
+        @DisplayName("blank condition throws RuleCompilationException naming the rule")
         void blankConditionThrows() {
             StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
             Rule rule = Rule.builder().ruleName("my-rule").condition("   ")
                     .action("output.put(\"k\",1)").build();
 
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            RuleCompilationException ex = assertThrows(RuleCompilationException.class,
                     () -> engine.setRuleList(List.of(rule)));
             assertTrue(ex.getMessage().contains("my-rule"));
             assertTrue(ex.getMessage().contains("condition"));
         }
 
         @Test
-        @DisplayName("empty string condition throws IllegalArgumentException")
+        @DisplayName("empty string condition throws RuleCompilationException")
         void emptyConditionThrows() {
             StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
             Rule rule = Rule.builder().ruleName("my-rule").condition("")
                     .action("output.put(\"k\",1)").build();
 
-            assertThrows(IllegalArgumentException.class, () -> engine.setRuleList(List.of(rule)));
+            assertThrows(RuleCompilationException.class, () -> engine.setRuleList(List.of(rule)));
         }
 
         @Test
@@ -478,7 +499,7 @@ class AbstractRulesEngineTest {
             StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
             Rule rule = Rule.builder().condition(null).action("output.put(\"k\",1)").build();
 
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            RuleCompilationException ex = assertThrows(RuleCompilationException.class,
                     () -> engine.setRuleList(List.of(rule)));
             assertTrue(ex.getMessage().contains("(unnamed)"));
         }
@@ -489,24 +510,24 @@ class AbstractRulesEngineTest {
     class RuleActionValidation {
 
         @Test
-        @DisplayName("null action throws IllegalArgumentException naming the rule")
+        @DisplayName("null action throws RuleCompilationException naming the rule")
         void nullActionThrows() {
             StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
             Rule rule = Rule.builder().ruleName("my-rule").condition("true").action(null).build();
 
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            RuleCompilationException ex = assertThrows(RuleCompilationException.class,
                     () -> engine.setRuleList(List.of(rule)));
             assertTrue(ex.getMessage().contains("my-rule"));
             assertTrue(ex.getMessage().contains("action"));
         }
 
         @Test
-        @DisplayName("blank action throws IllegalArgumentException naming the rule")
+        @DisplayName("blank action throws RuleCompilationException naming the rule")
         void blankActionThrows() {
             StatefulRulesEngine<Map<String, Object>> engine = new StatefulRulesEngine<>(HashMap::new);
             Rule rule = Rule.builder().ruleName("my-rule").condition("true").action("  ").build();
 
-            IllegalArgumentException ex = assertThrows(IllegalArgumentException.class,
+            RuleCompilationException ex = assertThrows(RuleCompilationException.class,
                     () -> engine.setRuleList(List.of(rule)));
             assertTrue(ex.getMessage().contains("my-rule"));
             assertTrue(ex.getMessage().contains("action"));


### PR DESCRIPTION
Closes #27

## The bug

The `RulesEngine#setRuleList` Javadoc and the README say invalid rules produce `RuleCompilationException`, but two kinds of invalid input didn't:

| Input | Before | After |
|---|---|---|
| null or blank condition / action | `IllegalArgumentException` | `RuleCompilationException` |
| `null` element in the rule list | bare `NullPointerException` from `Rule::getPriority` during sorting, no context | `RuleCompilationException: Rule at index 1 of the rule list is null` |

Neither `IllegalArgumentException` nor `NullPointerException` extends `UnrulyException`, so `catch (UnrulyException e)` let both escape.

## The fix

- `compileRule` throws `RuleCompilationException` for null or blank expressions, with unchanged messages that still name the rule, or `(unnamed)`.
- `setRuleList` checks for `null` elements **before** sorting and reports the index. A `null` list itself still throws `NullPointerException("ruleList must not be null")`: that's an invalid argument, not an invalid rule.
- The `RulesEngine#setRuleList` Javadoc lists every case, and the README exception section matches it.

## ⚠️ Behavior change

Titled `fix:` (patch release). Callers catching `IllegalArgumentException` from `setRuleList()` for blank expressions must catch `RuleCompilationException` or `UnrulyException` instead. The existing tests asserted the old type and have been updated.

## Tests

`AbstractRulesEngineTest`:
- the 6 existing condition/action validation tests now expect `RuleCompilationException` and still check that the message names the rule
- new: a `null` element throws `RuleCompilationException` naming index 1
- new: a blank condition can be caught as `UnrulyException`

Against the previous engine, **8 tests fail**: the 6 updated tests and the 2 new ones. `./gradlew clean build jacocoTestReport` passes locally, including the 100% Jacoco gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SoPR5C3L6SHbGFQHG9J7k7
